### PR TITLE
Add support for rebooting a container

### DIFF
--- a/novadocker/virt/docker/driver.py
+++ b/novadocker/virt/docker/driver.py
@@ -440,4 +440,3 @@ class DockerDriver(driver.ComputeDriver):
 
     def get_host_uptime(self, host):
         return hostutils.sys_uptime()
-


### PR DESCRIPTION
Without this patch, whenever a container is rebooted in OpenStack it will loose its IP address.
The reason is that the container PID will change, but the namespace link (in /var/run/netns/) is not updated to the new PID.

A fix is to destroy networking and create it again, which we tested successfully against nova-compute 1:2014.1-0ubuntu1.2
