### PR TITLE
Fix starting devstack with latest docker registry image

### DIFF
--- a/contrib/devstack/prepare_devstack.sh
+++ b/contrib/devstack/prepare_devstack.sh
@@ -18,7 +18,7 @@ cat - <<-EOF >> $INSTALLDIR/devstack/localrc
 export VIRT_DRIVER=docker
 export HOST_IP=$HOST_IP
 export KEYSTONE_ADMIN_BIND_HOST=0.0.0.0
-export DOCKER_REGISTRY_IMAGE=registry
+export DOCKER_REGISTRY_IMAGE=registry:0.6.9
 export DEFAULT_IMAGE_NAME=cirros
 export IMAGE_URLS=" "
 EOF


### PR DESCRIPTION
Without version of docker image, docker run crashed like in this bug:
https://github.com/rackerlabs/vagrant-solum-dev/issues/7
