### PR TITLE
Fixed a bug with the disappearance of the attributes after applying t…

### DIFF
--- a/novadocker/virt/docker/driver.py
+++ b/novadocker/virt/docker/driver.py
@@ -467,8 +467,7 @@ class DockerDriver(driver.ComputeDriver):
     def _start_container(self, container_id, instance, network_info=None):
         binds = self._get_key_binds(container_id, instance)
         dns = self._extract_dns_entries(network_info)
-        self.docker.start(container_id, binds=binds, dns=dns,
-                          privileged=CONF.docker.privileged)
+        self.docker.start(container_id, binds=binds, dns=dns)
 
         if not network_info:
             return
@@ -511,6 +510,7 @@ class DockerDriver(driver.ComputeDriver):
             'mem_limit': self._get_memory_limit_bytes(instance),
             'cpu_shares': self._get_cpu_shares(instance),
             'network_disabled': True,
+            'privileged': CONF.docker.privileged,
         }
 
         try:


### PR DESCRIPTION
…he privileged flag. In particular cpu_shares.

Hello! I using privileged flag in config file. When I create instance, it don't have attribute cpu_shares! I think, this is bug. Privileged flag should determined in create_container def! Thanks! Sry, for my bad english! I fix this is in pull_request, this is work! 
